### PR TITLE
MPS support and updates for pytorch 2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ pip install torchvision
 git clone https://github.com/meliketoy/wide-resnet.pytorch
 ```
 
+## Apple Silicon (MPS) support
+The code runs on Apple Silicon Macs via PyTorch's MPS backend. The device is selected automatically (MPS > CUDA > CPU).
+
+```bash
+pip install torch torchvision   # PyTorch 2.x with MPS support built in
+python main.py --net_type wide-resnet --depth 28 --widen_factor 10 --dropout 0.3 --dataset cifar10
+```
+
+Note: MPS does not support `DataParallel` or `torch.compile`, and `num_workers` is set to 0 on macOS due to its multiprocessing `spawn` context.
+
 ## How to run
 After you have cloned the repository, you can train each dataset of either cifar10, cifar100 by running the script below.
 ```bash

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ import argparse
 import datetime
 
 from networks import *
-from torch.autograd import Variable
 
 parser = argparse.ArgumentParser(description='PyTorch CIFAR-10 Training')
 parser.add_argument('--lr', default=0.1, type=float, help='learning_rate')
@@ -30,8 +29,18 @@ parser.add_argument('--resume', '-r', action='store_true', help='resume from che
 parser.add_argument('--testOnly', '-t', action='store_true', help='Test mode with the saved model')
 args = parser.parse_args()
 
-# Hyper Parameter settings
-use_cuda = torch.cuda.is_available()
+# Device selection: MPS > CUDA > CPU
+if torch.backends.mps.is_available():
+    device = torch.device('mps')
+    print('| Using MPS (Apple Silicon GPU)')
+elif torch.cuda.is_available():
+    device = torch.device('cuda')
+    print('| Using CUDA GPU')
+    cudnn.benchmark = True
+else:
+    device = torch.device('cpu')
+    print('| Using CPU')
+
 best_acc = 0
 start_epoch, num_epochs, batch_size, optim_type = cf.start_epoch, cf.num_epochs, cf.batch_size, cf.optim_type
 
@@ -53,17 +62,20 @@ if(args.dataset == 'cifar10'):
     print("| Preparing CIFAR-10 dataset...")
     sys.stdout.write("| ")
     trainset = torchvision.datasets.CIFAR10(root='./data', train=True, download=True, transform=transform_train)
-    testset = torchvision.datasets.CIFAR10(root='./data', train=False, download=False, transform=transform_test)
+    testset = torchvision.datasets.CIFAR10(root='./data', train=False, download=True, transform=transform_test)
     num_classes = 10
 elif(args.dataset == 'cifar100'):
     print("| Preparing CIFAR-100 dataset...")
     sys.stdout.write("| ")
     trainset = torchvision.datasets.CIFAR100(root='./data', train=True, download=True, transform=transform_train)
-    testset = torchvision.datasets.CIFAR100(root='./data', train=False, download=False, transform=transform_test)
+    testset = torchvision.datasets.CIFAR100(root='./data', train=False, download=True, transform=transform_test)
     num_classes = 100
 
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=2)
-testloader = torch.utils.data.DataLoader(testset, batch_size=100, shuffle=False, num_workers=2)
+# macOS uses 'spawn' for multiprocessing, which conflicts with top-level script code;
+# use num_workers=0 there and the default 2 elsewhere.
+num_workers = 0 if sys.platform == 'darwin' else 2
+trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size, shuffle=True, num_workers=num_workers)
+testloader = torch.utils.data.DataLoader(testset, batch_size=100, shuffle=False, num_workers=num_workers)
 
 # Return network & file name
 def getNetwork(args):
@@ -90,25 +102,20 @@ if (args.testOnly):
     print('\n[Test Phase] : Model setup')
     assert os.path.isdir('checkpoint'), 'Error: No checkpoint directory found!'
     _, file_name = getNetwork(args)
-    checkpoint = torch.load('./checkpoint/'+args.dataset+os.sep+file_name+'.t7')
+    checkpoint = torch.load('./checkpoint/'+args.dataset+os.sep+file_name+'.t7', weights_only=False)
     net = checkpoint['net']
 
-    if use_cuda:
-        net.cuda()
+    net.to(device)
+    if device.type == 'cuda':
         net = torch.nn.DataParallel(net, device_ids=range(torch.cuda.device_count()))
-        cudnn.benchmark = True
-
     net.eval()
-    net.training = False
     test_loss = 0
     correct = 0
     total = 0
 
     with torch.no_grad():
         for batch_idx, (inputs, targets) in enumerate(testloader):
-            if use_cuda:
-                inputs, targets = inputs.cuda(), targets.cuda()
-            inputs, targets = Variable(inputs), Variable(targets)
+            inputs, targets = inputs.to(device), targets.to(device)
             outputs = net(inputs)
 
             _, predicted = torch.max(outputs.data, 1)
@@ -127,7 +134,7 @@ if args.resume:
     print('| Resuming from checkpoint...')
     assert os.path.isdir('checkpoint'), 'Error: No checkpoint directory found!'
     _, file_name = getNetwork(args)
-    checkpoint = torch.load('./checkpoint/'+args.dataset+os.sep+file_name+'.t7')
+    checkpoint = torch.load('./checkpoint/'+args.dataset+os.sep+file_name+'.t7', weights_only=False)
     net = checkpoint['net']
     best_acc = checkpoint['acc']
     start_epoch = checkpoint['epoch']
@@ -136,17 +143,15 @@ else:
     net, file_name = getNetwork(args)
     net.apply(conv_init)
 
-if use_cuda:
-    net.cuda()
+net.to(device)
+if device.type == 'cuda':
     net = torch.nn.DataParallel(net, device_ids=range(torch.cuda.device_count()))
-    cudnn.benchmark = True
 
 criterion = nn.CrossEntropyLoss()
 
 # Training
 def train(epoch):
     net.train()
-    net.training = True
     train_loss = 0
     correct = 0
     total = 0
@@ -154,10 +159,8 @@ def train(epoch):
 
     print('\n=> Training Epoch #%d, LR=%.4f' %(epoch, cf.learning_rate(args.lr, epoch)))
     for batch_idx, (inputs, targets) in enumerate(trainloader):
-        if use_cuda:
-            inputs, targets = inputs.cuda(), targets.cuda() # GPU settings
+        inputs, targets = inputs.to(device), targets.to(device)
         optimizer.zero_grad()
-        inputs, targets = Variable(inputs), Variable(targets)
         outputs = net(inputs)               # Forward Propagation
         loss = criterion(outputs, targets)  # Loss
         loss.backward()  # Backward Propagation
@@ -177,15 +180,12 @@ def train(epoch):
 def test(epoch):
     global best_acc
     net.eval()
-    net.training = False
     test_loss = 0
     correct = 0
     total = 0
     with torch.no_grad():
         for batch_idx, (inputs, targets) in enumerate(testloader):
-            if use_cuda:
-                inputs, targets = inputs.cuda(), targets.cuda()
-            inputs, targets = Variable(inputs), Variable(targets)
+            inputs, targets = inputs.to(device), targets.to(device)
             outputs = net(inputs)
             loss = criterion(outputs, targets)
 
@@ -201,7 +201,7 @@ def test(epoch):
         if acc > best_acc:
             print('| Saving Best model...\t\t\tTop1 = %.2f%%' %(acc))
             state = {
-                    'net':net.module if use_cuda else net,
+                    'net':net.module if device.type == 'cuda' else net,
                     'acc':acc,
                     'epoch':epoch,
             }

--- a/main.py
+++ b/main.py
@@ -145,6 +145,7 @@ else:
 
 net.to(device)
 if device.type == 'cuda':
+    # Only apply DataParallel on cuda; not supported on MPS.
     net = torch.nn.DataParallel(net, device_ids=range(torch.cuda.device_count()))
 
 criterion = nn.CrossEntropyLoss()
@@ -201,7 +202,7 @@ def test(epoch):
         if acc > best_acc:
             print('| Saving Best model...\t\t\tTop1 = %.2f%%' %(acc))
             state = {
-                    'net':net.module if device.type == 'cuda' else net,
+                    'net':net.module if device.type == 'cuda' else net,  # Unwrap because of the DataParallel net
                     'acc':acc,
                     'epoch':epoch,
             }


### PR DESCRIPTION
## Summary

This PR modernises `main.py` to run on Apple Silicon Macs via PyTorch's MPS backend,
removes deprecated APIs that produce warnings or errors on current PyTorch versions,
and adds a short MPS section to the README.

No changes to model architecture, hyperparameters, or training logic.

## Changes

### `main.py`

**Device selection**

Chooses MPS over CUDA over GPU.

**Deprecated API removals**
- Removed `from torch.autograd import Variable` and all `Variable(...)` wrapping
  (no-op since PyTorch 0.4; raises deprecation warnings on current versions)
- Removed `net.training = False` assignments (redundant; `net.eval()` already sets this)
- Added `weights_only=False` to both `torch.load()` calls to silence the
  `FutureWarning` on PyTorch ≥ 2.0
- Fixed `testset` download flag from `download=False` to `download=True` so a
  fresh environment works without pre-downloading the test split separately

### `README.md`

Added an "Apple Silicon (MPS) support" section before "How to run".

## Test results

All accuracy numbers are directly measured from training logs (single runs).

### CPU — 3-epoch sanity check (no GPU, RunPod server CPU)

| Epoch | Val loss | Val acc |
|------:|:--------:|:-------:|
| 1     | 1.5897   | 48.10%  |
| 2     | 1.8262   | 47.91%  |
| 3     | 1.5577   | 54.09%  |

Confirms the code runs without a GPU.

### MPS — 44-epoch partial run (MacBook Air, Apple Silicon, PyTorch 2.10.0)

Run was stopped early to free the machine; training was proceeding normally.

| Epoch | Val acc |
|------:|:-------:|
| 1     | 50.91%  |
| 10    | ~75%    |
| 40    | 83.46%  |
| 44    | 79.87%  |

Epoch 44 is still in the flat middle of the LR schedule (first drop at epoch 60);
accuracy is expected to accelerate toward the final result after that.

### CUDA — full 200-epoch run (2× NVIDIA A100 SXM4-80GB, DataParallel)

| Epoch | Val acc  |
|------:|:--------:|
| 1     | ~48%     |
| 100   | ~93%     |
| 184   | 95.34%   | ← best checkpoint
| 200   | 95.07%   |

The reference result in the README (96.27%) is the **average of 5 runs**. A single
run at 95.07% is consistent with expected run-to-run variance.

## Log files

[MPS](https://github.com/user-attachments/files/25780821/mps_20260305_173736.log)
[CUDA](https://github.com/user-attachments/files/25780816/cuda_full_20260305_192835.log)

## Notes

- Tested with PyTorch 2.10.0 / torchvision 0.25.0.